### PR TITLE
Fix for not joining FIelds params

### DIFF
--- a/rfapi/connectapiclient.py
+++ b/rfapi/connectapiclient.py
@@ -330,6 +330,9 @@ class ConnectApiClient(BaseApiClient):
         if 'fields' in params and isinstance(params['fields'], list):
             params['fields'] = ",".join(params['fields'])
 
+        if 'metadata' in params:
+            assert isinstance(params['metadata'], bool)
+
         response = self._query("%s/%s" % (category, name), params)
         return DotAccessDict(response.result)
 

--- a/rfapi/connectapiclient.py
+++ b/rfapi/connectapiclient.py
@@ -323,7 +323,14 @@ class ConnectApiClient(BaseApiClient):
         Returns:
           A DotAccessDict object with entity information
         """
-        response = self._query("%s/%s" % (category, name), kwargs)
+
+        params = dict((snake_to_camel_case(k), v) for (k, v) in kwargs.items()
+                      if v is not None)
+
+        if 'fields' in params and isinstance(params['fields'], list):
+            params['fields'] = ",".join(params['fields'])
+
+        response = self._query("%s/%s" % (category, name), params)
         return DotAccessDict(response.result)
 
     def get_extension_info(self, category, entity,


### PR DESCRIPTION
Here the fix for #1. The same method for joining the field names was used as in search method. I've not run the tests simple because that it looked like it would require a lot of API tokens.

Hope it helps!